### PR TITLE
feat: Create main menu structure and loading logic

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,24 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const appContainer = document.getElementById('app_container');
+
+    if (appContainer) {
+        // Carica la schermata del menu principale all'avvio
+        fetch('main_menu/struttura_main_menu.html')
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error(`Errore nel caricamento del file: ${response.statusText}`);
+                }
+                return response.text();
+            })
+            .then(html => {
+                appContainer.innerHTML = html;
+                console.log('Menu principale caricato con successo.');
+            })
+            .catch(error => {
+                console.error('Impossibile caricare il menu principale:', error);
+                appContainer.innerHTML = '<p style="color: red; text-align: center;">Errore nel caricamento del menu principale.</p>';
+            });
+    } else {
+        console.error('Elemento "app_container" non trovato.');
+    }
+});

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
         }
     </style>
     <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="main_menu/stili_main_menu.css">
 </head>
 <body>
     <div id="app_container"></div>

--- a/main_menu/stili_main_menu.css
+++ b/main_menu/stili_main_menu.css
@@ -1,0 +1,103 @@
+/* Stile per il contenitore principale del gioco */
+.game_container {
+    width: 100vw;
+    height: 100vh;
+    border: none;
+    overflow: hidden;
+    background-image: url('main_menu_assets/img/main_menu_background.png');
+    background-color: #000000; /* Fallback nero */
+    background-size: cover;
+    background-position: center;
+    position: relative;
+}
+
+/* Stile per lo schermo di sovrapposizione */
+.overlay_screen {
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.75);
+    border: none;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+}
+
+/* Stile per il box del nome del gioco */
+.nome_del_gioco {
+    position: absolute;
+    top: 3%;
+    left: 50%;
+    transform: translateX(-50%);
+    height: 5%;
+    width: 100%;
+    text-align: center;
+    color: #ffffff;
+}
+
+.nome_del_gioco h1 {
+    font-size: 4vh; /* Dimensione del font relativa all'altezza del viewport */
+    font-family: sans-serif; /* Un font solido e leggibile di default */
+    font-weight: bold;
+    margin: 0;
+    line-height: 1;
+}
+
+/* Stile per il contenitore dei pulsanti del menu */
+.contenitore_pulsanti_main_menu {
+    width: 50%;
+    height: 70%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+
+/* Stile per il titolo "MAIN MENU" */
+.titolo_menu {
+    width: 90%;
+    height: 10%;
+    background-color: transparent;
+    border: none;
+    text-align: center;
+    color: #ffffff;
+    margin-bottom: 20px; /* Spazio tra il titolo e il primo pulsante */
+}
+
+.titolo_menu h2 {
+    font-family: sans-serif;
+    font-weight: bold;
+    font-size: 3vh;
+    padding: 5px;
+    margin: 0;
+}
+
+/* Stile per i pulsanti del menu */
+.stile_pulsanti_main_menu {
+    width: 80%;
+    margin: 10px 0; /* Spazio verticale tra i pulsanti */
+    padding: 15px 0; /* Padding verticale interno */
+    border-radius: 8px;
+    border: none;
+    background-color: #246A73; /* Verde Caribbean Current */
+    color: #ffffff;
+    font-size: 1.8vh;
+    font-weight: bold;
+    cursor: pointer;
+    text-align: center;
+    transition: transform 0.2s ease-in-out, background-color 0.2s ease-in-out;
+}
+
+/* Effetto al passaggio del mouse */
+.stile_pulsanti_main_menu:hover {
+    background-color: #8BE8CB; /* Verde Acquamarina */
+    color: #000000;
+    transform: scale(1.05); /* Effetto zoom */
+}
+
+/* Effetto al click del mouse */
+.stile_pulsanti_main_menu:active {
+    background-color: #12664F; /* Castleton Green */
+    transform: scale(1.02); /* Leggera riduzione dello zoom al click */
+}

--- a/main_menu/struttura_main_menu.html
+++ b/main_menu/struttura_main_menu.html
@@ -1,0 +1,18 @@
+<div class="game_container">
+    <div class="overlay_screen">
+        <div class="nome_del_gioco">
+            <h1>NOME DEL GIOCO</h1>
+        </div>
+        <div class="contenitore_pulsanti_main_menu">
+            <div class="titolo_menu">
+                <h2>MAIN MENU</h2>
+            </div>
+            <button class="stile_pulsanti_main_menu">NUOVA PARTITA</button>
+            <button class="stile_pulsanti_main_menu">CARICA PARTITA</button>
+            <button class="stile_pulsanti_main_menu">OPZIONI</button>
+            <button class="stile_pulsanti_main_menu">IN GAME EDITOR</button>
+            <button class="stile_pulsanti_main_menu">CREDITS</button>
+            <button class="stile_pulsanti_main_menu">ESCI DAL GIOCO</button>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
- Creates the directory structure for the main menu, including asset folders for images and audio.
- Adds `struttura_main_menu.html` with the main menu's DOM elements.
- Adds `stili_main_menu.css` to style the main menu, including responsive sizing and button interaction effects.
- Creates an empty `logica_main_menu.js` for future implementation.
- Updates `index.html` to link the new stylesheet.
- Updates `app.js` to dynamically fetch and load the main menu screen into the `app_container` on startup.